### PR TITLE
docs: update project documentation and steering guides

### DIFF
--- a/.kiro/steering/product.md
+++ b/.kiro/steering/product.md
@@ -1,21 +1,27 @@
 # Product Overview
 
-**laag** is a collection of JavaScript libraries for interfacing with different API specification formats, including Swagger/OpenAPI, RAML, and potentially AWS/Azure formats.
+**laag** is a collection of JavaScript/TypeScript libraries for interfacing with different API specification formats, including OpenAPI/Swagger, AWS Smithy, and RAML.
 
 ## Current Status
-- Work in progress
-- Primary focus on OpenAPI/Swagger support via `@laag/openapi` package
-- RAML support in development via `@laag/raml` package
-- Smithy support planned
+- **Production Ready**: OpenAPI/Swagger support via `@laag/openapi` package (v2.0+)
+- **Production Ready**: AWS Smithy support via `@laag/smithy` package (v1.0-alpha)
+- **In Development**: RAML support via `@laag/raml` package (v1.0-alpha)
+- **Stable**: Core utilities via `@laag/core` package (v2.0+)
+- **Stable**: CLI tool via `@laag/cli` package (v2.0+)
 
 ## Key Features
-- Read and write Swagger/OpenAPI documents
+- Read and write OpenAPI/Swagger documents
+- Parse and manipulate AWS Smithy models
+- Code generation (TypeScript, JavaScript, Python)
 - Unified interface across different API specification formats
-- CommonJS modules compatible with Node.js and modern browsers
+- Full TypeScript support with comprehensive type definitions
+- ESM and CommonJS modules compatible with Node.js, browsers, and edge environments
 - Programmatic API for creating, modifying, and analyzing API specifications
+- Sample generation and validation
 
 ## Target Use Cases
 - API documentation tooling
 - API specification validation and transformation
-- Automated API client/server generation
+- Automated API client/server generation from Smithy models
 - API design and development workflows
+- Cross-format API specification conversion

--- a/.kiro/steering/structure.md
+++ b/.kiro/steering/structure.md
@@ -4,10 +4,11 @@
 ```
 laag/
 ├── packages/                    # Bun workspace packages
-│   ├── openapi/                # OpenAPI/Swagger library
-│   ├── raml/                   # RAML library (in development)
-│   ├── smithy/                 # Smithy library (planned)
-│   └── core/                   # Shared core functionality
+│   ├── core/                   # Shared core functionality (v2.0+)
+│   ├── openapi/                # OpenAPI/Swagger library (v2.0+)
+│   ├── smithy/                 # AWS Smithy library (v1.0-alpha)
+│   ├── raml/                   # RAML library (v1.0-alpha, in development)
+│   └── cli/                    # Command-line interface (v2.0+)
 ├── scripts/                    # Build and release scripts
 ├── coverage/                   # Test coverage reports
 ├── .husky/                     # Git hooks configuration
@@ -20,30 +21,40 @@ Each package follows a consistent structure:
 ```
 packages/{format}/
 ├── package.json                # Package configuration
-├── lib/                        # Compiled/built library files
-│   └── laag-{format}.js       # Main library file
+├── src/                        # TypeScript source files
+│   ├── index.ts               # Main entry point
+│   ├── {format}.ts            # Main class implementation
+│   └── types.ts               # Type definitions
+├── dist/                       # Built library files
+│   ├── esm/                   # ESM build
+│   ├── cjs/                   # CommonJS build
+│   ├── browser/               # Browser bundle
+│   └── types/                 # Type declarations
 ├── __tests__/                  # Test files
-│   ├── laag-{format}.test.js  # Main tests
-│   └── laag-{format}-component.test.js # Component tests
+│   ├── {format}.test.ts       # Main tests
+│   ├── integration.test.ts    # Integration tests
+│   └── fixtures/              # Test fixtures
 ├── examples/                   # Usage examples
-│   ├── read-example.js        # Reading examples
-│   ├── write-example.js       # Writing examples
-│   └── *.json/*.raml          # Sample specification files
-├── src/                        # Source files (if applicable)
+│   ├── basic-usage.ts         # Basic examples
+│   ├── code-generation.ts     # Code generation examples (Smithy)
+│   └── models/                # Sample model files
 └── README.md                   # Package documentation
 ```
 
 ## Naming Conventions
-- **Packages**: `@laag/{format}` for published packages, `{format}` for internal
-- **Main files**: `laag-{format}.js` in lib directory
-- **Test files**: `laag-{format}.test.js` and `laag-{format}-component.test.js`
-- **Classes**: PascalCase (e.g., `Openapi`, `Core`)
+- **Packages**: `@laag/{format}` for published packages (e.g., @laag/openapi, @laag/smithy)
+- **Main files**: `{format}.ts` in src directory (e.g., openapi.ts, smithy.ts)
+- **Test files**: `{format}.test.ts`, `integration.test.ts`, `{feature}.test.ts`
+- **Classes**: PascalCase (e.g., `Openapi`, `Smithy`, `LaagBase`)
 - **Methods**: camelCase with descriptive names
+- **Types**: PascalCase with descriptive suffixes (e.g., `SmithyModel`, `ValidationResult`)
 - **Extensions**: Use `getExtensions()` pattern for x-* properties
 
 ## File Organization Rules
-- Keep main library logic in `lib/` directory
+- Keep TypeScript source in `src/` directory
+- Built artifacts go in `dist/` directory (esm, cjs, browser, types)
 - Place all tests in `__tests__/` directory
 - Provide working examples in `examples/` directory
 - Use consistent README structure across packages
 - Maintain separate package.json for each package with proper metadata
+- Include fixtures and sample models in `__tests__/fixtures/` or `examples/models/`

--- a/.kiro/steering/tech.md
+++ b/.kiro/steering/tech.md
@@ -6,23 +6,31 @@
 - **Module System**: ESM modules with CommonJS compatibility
 
 ## Core Technologies
-- **Runtime**: Node.js
-- **Language**: JavaScript (ES5/CommonJS style)
+- **Runtime**: Node.js 18+, Bun
+- **Language**: TypeScript (compiled to JavaScript)
 - **Testing**: Bun test framework with standard test patterns
 - **Dependencies**: Minimal external dependencies (js-yaml for YAML parsing)
 
 ## Project Structure
-- Lerna-managed monorepo with packages in `packages/` directory
-- Each package has its own `package.json`, tests, examples, and lib directory
-- Source code compiled/built into `lib/` directories
+- Bun workspace monorepo with packages in `packages/` directory
+- Each package has its own `package.json`, tests, examples, and dist directory
+- TypeScript source code in `src/` directories
+- Built artifacts in `dist/` directories (esm, cjs, browser, types)
 - Tests located in `__tests__/` directories
 
 ## Common Commands
 
 ### Testing
 ```bash
-# Run tests for individual packages
-cd packages/openapi && bun test
+# Run tests for all packages
+bun test
+
+# Run tests for specific package
+bun test packages/openapi
+bun test packages/smithy
+
+# Run tests with coverage
+bun test --coverage
 
 # Tests use Bun test framework with imports like:
 # import { describe, expect, test, beforeAll } from 'bun:test'
@@ -41,7 +49,11 @@ bun run workspace:build             # Build all packages
 ```
 
 ## Code Patterns
-- Class-based architecture with static utility methods
+- Class-based architecture with TypeScript
+- Static utility methods for common operations
 - Extension methods for API specification extensions (x-* properties)
 - Helper methods for nested object key existence checking
-- Consistent naming: `laag-{format}.js` for main library files
+- Consistent naming: `{format}.ts` for main class files (e.g., openapi.ts, smithy.ts)
+- Type-safe interfaces and type definitions
+- Validation methods returning structured ValidationResult objects
+- Code generation methods for TypeScript, JavaScript, and Python

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **@laag/smithy** - Complete AWS Smithy model support with:
+  - Full TypeScript implementation with comprehensive type definitions
+  - Shape management (services, operations, structures, resources)
+  - Trait support (standard and custom traits)
+  - Code generation (TypeScript, JavaScript, Python)
+  - Selector support for querying shapes
+  - Model validation according to Smithy specification
+  - HTTP binding extraction
 - Complete TypeScript rewrite with full type safety
 - Modern ESM and CommonJS dual module support
 - Browser-compatible bundles with tree-shaking
@@ -40,9 +48,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Various type safety issues in the original JavaScript implementation
 - Inconsistent error handling across packages
+- CI test failures due to missing build artifacts in test jobs
 
 ### Security
 
+- Updated js-yaml from 4.1.0 to 4.1.1 to fix prototype pollution vulnerability (GHSA-mh29-5h37-fv8m)
+- Added resolution for js-yaml to force version 4.1.1+ across all transitive dependencies
 - Updated all dependencies to latest secure versions
 - Added automated security scanning in CI/CD
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ A modern TypeScript library collection for working with API specification format
 
 - **[@laag/core](packages/core/)** - Core utilities and base classes for all laag packages
 - **[@laag/openapi](packages/openapi/)** - Comprehensive OpenAPI/Swagger document parsing and manipulation
-- **[@laag/raml](packages/raml/)** - RAML document support (coming soon)
+- **[@laag/smithy](packages/smithy/)** - AWS Smithy model support with code generation
+- **[@laag/raml](packages/raml/)** - RAML document support (in development)
 - **[@laag/cli](packages/cli/)** - Command-line interface for analyzing API specifications
 
 ## Quick Start
@@ -74,6 +75,7 @@ laag --help
 
 - [Core Package](packages/core/README.md) - Base functionality and utilities
 - [OpenAPI Package](packages/openapi/README.md) - OpenAPI/Swagger support
+- [Smithy Package](packages/smithy/README.md) - AWS Smithy model support
 - [CLI Package](packages/cli/README.md) - Command-line interface
 - [Examples](examples/) - Usage examples and tutorials
 
@@ -123,12 +125,13 @@ bun run scripts/release.ts --version=1.2.3 --otp=123456
 ```bash
 # Release specific packages independently (will prompt for NPM OTP)
 bun run release:openapi:patch    # OpenAPI package patch
+bun run release:smithy:patch     # Smithy package patch
 bun run release:core:minor       # Core package minor
 bun run release:cli:major        # CLI package major
 
 # Or use the release script directly
 bun run scripts/release-package.ts @laag/openapi --patch
-bun run scripts/release-package.ts @laag/openapi --version=2.1.0
+bun run scripts/release-package.ts @laag/smithy --version=1.0.0
 
 # Provide OTP directly to avoid prompts
 bun run scripts/release.ts --packages=@laag/openapi --patch --otp=123456


### PR DESCRIPTION
- Update product overview to reflect current status: OpenAPI v2.0+, Smithy v1.0-alpha, RAML v1.0-alpha, and stable core/cli packages
- Add AWS Smithy as primary supported format alongside OpenAPI/Swagger
- Expand key features to include code generation, TypeScript support, and ESM/CommonJS compatibility
- Reorganize package structure documentation with version information and build output directories (esm, cjs, browser, types)
- Update naming conventions to reflect TypeScript source files and modern type definitions
- Revise tech stack documentation to specify Node.js 18+, Bun runtime, and TypeScript language
- Add comprehensive command examples for testing, building, and workspace management
- Update file organization rules to reflect src/ and dist/ directory structure
- Add details about fixtures and sample models organization
- Update CHANGELOG with latest changes and improvements

