### PR TITLE
chore(release): Bump package versions and clean up package metadata

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -25,7 +25,7 @@
     },
     "packages/cli": {
       "name": "@laag/cli",
-      "version": "0.0.2",
+      "version": "2.0.1",
       "bin": {
         "laag": "./laag-cli.js",
       },
@@ -41,14 +41,14 @@
     },
     "packages/core": {
       "name": "@laag/core",
-      "version": "0.0.2",
+      "version": "2.0.0",
       "devDependencies": {
         "typescript": "^6.0.2",
       },
     },
     "packages/openapi": {
       "name": "@laag/openapi",
-      "version": "0.0.2",
+      "version": "2.0.4",
       "devDependencies": {
         "@laag/core": "workspace:*",
         "@types/bun": "latest",
@@ -64,7 +64,7 @@
     },
     "packages/raml": {
       "name": "@laag/raml",
-      "version": "0.0.2",
+      "version": "1.0.1",
       "devDependencies": {
         "@laag/core": "workspace:*",
         "@types/bun": "latest",
@@ -80,7 +80,7 @@
     },
     "packages/smithy": {
       "name": "@laag/smithy",
-      "version": "0.0.2",
+      "version": "1.0.0",
       "devDependencies": {
         "@laag/core": "workspace:*",
         "@types/bun": "latest",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@laag/cli",
-  "version": "2.0.2",
+  "version": "2.0.1",
   "description": "Command-line interface for the laag library collection",
   "type": "module",
   "main": "laag-cli.js",
@@ -50,8 +50,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "path": "/Users/brettschwarz/repos/laag/packages/cli",
-  "packageJsonPath": "/Users/brettschwarz/repos/laag/packages/cli/package.json",
-  "directoryName": "cli"
+  }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -67,8 +67,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "path": "/Users/brettschwarz/repos/laag/packages/core",
-  "packageJsonPath": "/Users/brettschwarz/repos/laag/packages/core/package.json",
-  "directoryName": "core"
+  }
 }

--- a/packages/openapi/package.json
+++ b/packages/openapi/package.json
@@ -87,8 +87,5 @@
     "@laag/core": "workspace:*",
     "@types/bun": "latest",
     "typescript": "^6.0.2"
-  },
-  "path": "/Users/brettschwarz/repos/laag/packages/openapi",
-  "packageJsonPath": "/Users/brettschwarz/repos/laag/packages/openapi/package.json",
-  "directoryName": "openapi"
+  }
 }

--- a/packages/raml/package.json
+++ b/packages/raml/package.json
@@ -88,8 +88,5 @@
     "@laag/core": "workspace:*",
     "@types/bun": "latest",
     "typescript": "^6.0.2"
-  },
-  "path": "/Users/brettschwarz/repos/laag/packages/raml",
-  "packageJsonPath": "/Users/brettschwarz/repos/laag/packages/raml/package.json",
-  "directoryName": "raml"
+  }
 }

--- a/packages/smithy/package.json
+++ b/packages/smithy/package.json
@@ -91,8 +91,5 @@
     "@laag/core": "workspace:*",
     "@types/bun": "latest",
     "typescript": "^6.0.2"
-  },
-  "path": "/Users/brettschwarz/repos/laag/packages/smithy",
-  "packageJsonPath": "/Users/brettschwarz/repos/laag/packages/smithy/package.json",
-  "directoryName": "smithy"
+  }
 }

--- a/scripts/release-package.ts
+++ b/scripts/release-package.ts
@@ -71,23 +71,27 @@ class PackageReleaseManager {
   }
 
   private updateVersion(versionType?: string, customVersion?: string): string {
-    if (customVersion) {
-      this.packageInfo.version = customVersion;
-      writeFileSync(this.packageInfo.packageJsonPath, JSON.stringify(this.packageInfo, null, 2) + '\n');
-      return customVersion;
-    }
+      // Strip internal metadata before writing to disk
+      const { path: _path, packageJsonPath, directoryName, ...cleanPackageInfo } = this.packageInfo;
 
-    if (versionType) {
-      // Parse current version and bump it
-      const currentVersion = this.packageInfo.version;
-      const newVersion = this.bumpVersion(currentVersion, versionType);
-      this.packageInfo.version = newVersion;
-      writeFileSync(this.packageInfo.packageJsonPath, JSON.stringify(this.packageInfo, null, 2) + '\n');
-      return newVersion;
-    }
+      if (customVersion) {
+        cleanPackageInfo.version = customVersion;
+        this.packageInfo.version = customVersion;
+        writeFileSync(packageJsonPath, JSON.stringify(cleanPackageInfo, null, 2) + '\n');
+        return customVersion;
+      }
 
-    return this.packageInfo.version;
-  }
+      if (versionType) {
+        const currentVersion = this.packageInfo.version;
+        const newVersion = this.bumpVersion(currentVersion, versionType);
+        cleanPackageInfo.version = newVersion;
+        this.packageInfo.version = newVersion;
+        writeFileSync(packageJsonPath, JSON.stringify(cleanPackageInfo, null, 2) + '\n');
+        return newVersion;
+      }
+
+      return this.packageInfo.version;
+    }
 
   private bumpVersion(currentVersion: string, versionType: string): string {
     const parts = currentVersion.split('.');


### PR DESCRIPTION
- Update @laag/cli version from 0.0.2 to 2.0.1
- Update @laag/core version from 0.0.2 to 2.0.0
- Update @laag/openapi version from 0.0.2 to 2.0.4
- Update @laag/raml version from 0.0.2 to 1.0.1
- Update @laag/smithy version from 0.0.2 to 1.0.0
- Remove internal metadata fields (path, packageJsonPath, directoryName) from all package.json files
- Refactor release-package.ts to strip internal metadata before writing package.json to disk
- Ensure clean package.json output without development-time metadata

# Pull Request

## Description
Brief description of the changes in this PR.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Test improvements
- [ ] Build/CI improvements

## Packages Affected
- [ ] @laag/core
- [ ] @laag/openapi
- [ ] @laag/raml
- [ ] @laag/smithy
- [ ] Build system
- [ ] Documentation

## Testing
- [ ] Tests pass locally
- [ ] New tests added for new functionality
- [ ] Existing tests updated if needed
- [ ] Manual testing completed

## Quality Checks
- [ ] Code follows the project's style guidelines
- [ ] Self-review of code completed
- [ ] Code is properly documented
- [ ] TypeScript types are accurate and complete
- [ ] No new linting errors introduced

## Breaking Changes
If this PR introduces breaking changes, please describe them here and update the version accordingly.

## Additional Notes
Any additional information, context, or screenshots that would be helpful for reviewers.

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes